### PR TITLE
add wrapper to replace pcre_info function

### DIFF
--- a/src/pattern.c
+++ b/src/pattern.c
@@ -26,6 +26,12 @@ static const char RCSid[] = "$Id: pattern.c,v 35004.4 2007/01/13 23:12:39 kkeys 
 #include "search.h"	/* for tfio.h */
 #include "tfio.h"
 
+int pcre_info(const pcre *argument_re, int *optptr, int *first_byte) {
+    int n = 0;
+    pcre_fullinfo(argument_re, NULL, 2, &n);
+    return n;
+}
+
 static RegInfo *reginfo = NULL;
 static const unsigned char *re_tables = NULL;
 
@@ -478,4 +484,3 @@ void free_patterns(void)
     }
 }
 #endif
-


### PR DESCRIPTION
This will allow tinyfugue to compile with recent versions of PCRE.