### PR TITLE
Handle unmatched attribute strings

### DIFF
--- a/src/expr.c
+++ b/src/expr.c
@@ -925,8 +925,10 @@ static Value *function_switch(const ExprFunc *func, int n, const char *parent)
 		    enum2int(opdstd(n-2), 0, enum_flag, "arg 3 (inline)") : 1;
 		constr = CS(i ? decode_attr(opdstr(n), 0, 0) :
 		    Stringdup(opdstr(n)));
+		if (!constr)
+		    return shareval(val_blank);
 		constr->attrs = adj_attr(constr->attrs, attr);
-		return constr ? newSstr(constr) : shareval(val_blank);
+		return newSstr(constr);
             }
 
         case FN_strip_attr:


### PR DESCRIPTION
The existing code was checking for a NULL string after dereferencing it, so
rearrange the code so it returns a blank_val first and then dereferencing if
it is a valid Constring.

Fixes #17 