### PR TITLE
chore: fix compiler warnings

### DIFF
--- a/help/html2tf.c
+++ b/help/html2tf.c
@@ -77,8 +77,9 @@ int main(int argc, char *argv[])
     int c, i, j;
     char *s, *t;
     long line;
-    int inlink, under, bold, inquote, inattr, iscomment, defwidth, dt;
+    int inlink, under, bold, inquote, inattr, iscomment, defwidth = 0, dt = 0;
 
+    (void)argc;
     while (*++argv) {
         line = 1;
         if (!(file = fopen(*argv, "r"))) {
@@ -118,6 +119,7 @@ int main(int argc, char *argv[])
                 tag[taglen] = '\0';
                 attr[attrlen] = '\0';
 		if (iscomment) {
+		    if (c == EOF) break;
 		    if (taglen < 5 || strcmp(tag + taglen - 2, "--") != 0)
 			goto continuetag;
 		}
@@ -379,8 +381,9 @@ int main(int argc, char *argv[])
                     }
                     /* fprintf(stderr, "longest = %d\n", maxvis); */
                     /* maxvis += 1; */
+                    if (maxvis <= 0) maxvis = 1;
                     cols = (MAX_LINE_LEN - margin - indent) / maxvis;
-                    /* fprintf(stderr, "cols = %d\n", cols); */
+                    if (cols <= 0) cols = 1;
                     rows = (dircount - 1) / cols + 1;
                     /* fprintf(stderr, "rows = %d\n", rows); */
                     for (i = 0; i < rows; i++) {
@@ -435,6 +438,7 @@ int main(int argc, char *argv[])
                     if (c == ';') break;
                     tag[taglen++] = c;
                 }
+                if (c == EOF) break;
                 tag[taglen] = '\0';
                 if (strcasecmp(tag, "amp") == 0) {
                     addc('&');

--- a/src/attr.c
+++ b/src/attr.c
@@ -334,7 +334,8 @@ attr_t adj_attr(attr_t base, attr_t adj)
 /* convert attr string to bitfields */
 const char *parse_attrs(const char *str, attr_t *attrp, int delimiter)
 {
-    int color, len;
+    int color;
+    size_t len;
     const char *name;
     char buf[16];
     char reject[3] = {',', '\0', '\0'};
@@ -689,7 +690,7 @@ String *attr2str(String *buffer, attr_t attrs)
 
 String *encode_attr(const conString *str, int offset)
 {
-    attr_t oldattrs = 0, attrs;
+    attr_t oldattrs = 0, attrs = 0;
     int i;
     String *new;
     
@@ -776,7 +777,7 @@ static String *attr2ansi(String *str, attr_t attrs)
 
 String *encode_ansi(const conString *str, int offset)
 {
-    attr_t oldattrs = 0, attrs;
+    attr_t oldattrs = 0, attrs = 0;
     int i;
     String *new;
     

--- a/src/expand.c
+++ b/src/expand.c
@@ -472,9 +472,9 @@ Value *prog_interpret(const Program *prog, int in_expr)
 {
     Value *val, *val2, *result = NULL;
     String *str, *tbuf;
-    conString *constr;
-    int cip, stackbot, no_arg;
-    int empty;	/* for varsub default */
+    conString *constr = NULL;
+    int cip, stackbot, no_arg = 0;
+    int empty = 0;	/* for varsub default */
     opcode_t op;
     int first, last, n;
     int instruction_count = 0;
@@ -1314,7 +1314,7 @@ static int list(Program *prog, int subs)
     int failed = 0, result = 0;
     const char *stmtstart;
     int is_pipe = 0;
-    int block_start, jump_point, oldlen;
+    int block_start = 0, jump_point = 0, oldlen;
 
     /* Do NOT strip leading space here.  This allows user to type and send
      * lines with leading spaces (but completely empty lines are handled

--- a/src/expr.c
+++ b/src/expr.c
@@ -674,7 +674,7 @@ reduce_exit:
 static int reduce_arithmetic(opcode_t op, const Value *val0, int n, Value *res)
 {
     int i;
-    int int0, int1, neg0, neg1, sum;
+    int int0, int1, neg0, neg1, sum = 0;
     double f;
     struct timeval t, t1;
     type_t type, promoted_type = 0;
@@ -1257,12 +1257,12 @@ static Value *function_switch(const ExprFunc *func, int n, const char *parent)
 		tm.tm_year = 0;
 		tm.tm_isdst = -1;
 		switch (n) {
-		    case 7: usec       = opdint(n-6);
-		    case 6: tm.tm_sec  = opdint(n-5);
-		    case 5: tm.tm_min  = opdint(n-4);
-		    case 4: tm.tm_hour = opdint(n-3);
-		    case 3: tm.tm_mday = opdint(n-2);
-		    case 2: tm.tm_mon  = opdint(n-1) - 1;
+		    case 7: usec       = opdint(n-6); /* fallthrough */
+		    case 6: tm.tm_sec  = opdint(n-5); /* fallthrough */
+		    case 5: tm.tm_min  = opdint(n-4); /* fallthrough */
+		    case 4: tm.tm_hour = opdint(n-3); /* fallthrough */
+		    case 3: tm.tm_mday = opdint(n-2); /* fallthrough */
+		    case 2: tm.tm_mon  = opdint(n-1) - 1; /* fallthrough */
 		    case 1: tm.tm_year = opdint(n-0) - 1900;
 		}
 		t = mktime(&tm);

--- a/src/history.c
+++ b/src/history.c
@@ -322,7 +322,7 @@ int do_recall(String *args, int offset)
     if ((locality = (ptr && *ptr == '?'))) ptr++;
 #endif
     if ((numbers = (ptr && *ptr == '#'))) ptr++;
-    while (is_space(*ptr)) ptr++;
+    while (ptr && is_space(*ptr)) ptr++;
 
     tvp0 = tvp1 = NULL;
     n0 = 0;

--- a/src/macro.c
+++ b/src/macro.c
@@ -238,13 +238,13 @@ static Macro *macro_spec(String *args, int offset, int *xmflag, ListOpts *listop
     while (!error && (opt = nextopt(&ptr, &uval, NULL, &offset))) {
         switch (opt) {
         case 'u':
-            listopts->usedflag = 1;
+            if (listopts) listopts->usedflag = 1;
             break;
         case 's':
-            listopts->shortflag = 1;
+            if (listopts) listopts->shortflag = 1;
             break;
         case 'S':
-            listopts->cmp = cstrpppcmp;
+            if (listopts) listopts->cmp = cstrpppcmp;
             break;
         case 'm':
             if (!(error = ((i = enum2int(ptr, 0, enum_match, "-m")) < 0))) {
@@ -343,12 +343,13 @@ static Macro *macro_spec(String *args, int offset, int *xmflag, ListOpts *listop
 
 	    {
 	    char *start, *end, *buf = STRDUP(ptr); /* XXX optimize */
-	    for (i = 0, start = buf; !error && i < n; i++, start = end+1) {
+	    for (i = 0, start = buf; !error && i < n; i++) {
 		attr_t attr;
 		if ((end = strchr(start, ';')))
 		    *end = '\0';
 		if (end == start) { /* skip empty */
 		    i--;
+		    start = end + 1;
 		    continue;
 		}
 		if (*start == 'L') {
@@ -366,6 +367,7 @@ static Macro *macro_spec(String *args, int offset, int *xmflag, ListOpts *listop
 		}
 		error = !parse_attrs(start, &attr, 0);
 		spec->subattr[i].attr = attr;
+		if (end) start = end + 1;
 	    }
 	    FREE(buf);
 	    }
@@ -1568,7 +1570,7 @@ int do_hook(int hooknum, const char *fmt, const char *argfmt, ...)
         va_end(ap);
     }
 
-    if (hookflag || hilite || gag) {
+    if (args) {
         ran = find_and_run_matches(args, hooknum, &line, xworld(), TRUE, 0);
         Stringfree(args);
     }
@@ -1626,6 +1628,10 @@ int find_and_run_matches(String *text, int hooknum, String **linep,
 	worldtype = "";
     if (!text)
         text = *linep;
+    if (!text) {
+        recur_count--;
+        return 0;
+    }
     text->links++; /* in case substitute() frees text */
     recur_count++;
     if (hooknum>=0) {
@@ -1687,7 +1693,7 @@ int find_and_run_matches(String *text, int hooknum, String **linep,
 			enqueue(runq, macro);
 		    } else {
 			ran += run_match(macro, text, hooknum);
-			if (linep && hooknum<0) {
+			if (linep && *linep && hooknum<0) {
 			    /* in case of /substitute */ /* XXX */
 			    Stringfree(text);
 			    text = *linep;
@@ -1890,7 +1896,7 @@ static int run_match(
 {
     int ran = 0;
     struct Sock *callingsock = xsock;
-    RegInfo *old;
+    RegInfo *old = NULL;
 
     if (hooknum < 0) { /* trigger */
 	if (!borg) return 0;

--- a/src/macro.h
+++ b/src/macro.h
@@ -36,7 +36,7 @@ extern int    find_and_run_matches(String *text, int hooknum, String **linep,
 		struct World *world, int globalflag, int exec_list_long);
 
 #define macro_hash(name) \
-    (!name ? 0 : (*name == '#') ? atoi(&name[1]) : hash_string(name))
+    (!name ? 0U : (*name == '#') ? (unsigned int)atoi(&name[1]) : hash_string(name))
 #define find_macro(name)    find_hashed_macro(name, macro_hash(name))
 
 #if USE_DMALLOC

--- a/src/makehelp.c
+++ b/src/makehelp.c
@@ -16,7 +16,7 @@
 
 #include <stdio.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
     char line[240+1];
     long offset = 0;

--- a/src/malloc.h
+++ b/src/malloc.h
@@ -65,11 +65,11 @@ extern void   dfree(void *md, void *ptr,
 #endif
 
 extern void  *xmalloc(void *md, long unsigned size,
-                       const char *file, const int line);
+                       const char *file, const int line) RETURNS_NONNULL;
 extern void  *xcalloc(void *md, long unsigned size,
-                       const char *file, const int line);
+                       const char *file, const int line) RETURNS_NONNULL;
 extern void  *xrealloc(void *md, void *ptr, long unsigned size,
-                       const char *file, const int line);
+                       const char *file, const int line) RETURNS_NONNULL;
 extern void      xfree(void *md, void *ptr,
                        const char *file, const int line);
 extern void      init_malloc(void);

--- a/src/output.c
+++ b/src/output.c
@@ -431,6 +431,7 @@ void init_output(void)
 static void init_term(void)
 {
 #if TERMCAP
+    const char *term = TERM;
     int i;
     /* Termcap entries are supposed to fit in 1024 bytes.  But, if a 'tc'
      * field is present, some termcap libraries will just append the second
@@ -483,10 +484,10 @@ static void init_term(void)
 	}
     }
 
-    if (!TERM || !*TERM) {
+    if (!term || !*term) {
         tfwprintf("TERM undefined.");
-    } else if (tgetent(termcap_entry, TERM) <= 0) {
-        tfwprintf("\"%s\" terminal unsupported.", TERM);
+    } else if (tgetent(termcap_entry, term) <= 0) {
+        tfwprintf("\"%s\" terminal unsupported.", term);
     } else {
         if (columns <= 0) columns = tgetnum("co");
         if (lines   <= 0) lines   = tgetnum("li");
@@ -537,7 +538,7 @@ static void init_term(void)
 
 	if (!keypad_off) keypad_on = NULL;
 
-        if (strcmp(TERM, "xterm") == 0) {
+        if (strcmp(term, "xterm") == 0) {
 #if 0	    /* Now that tf has virtual screens, the secondary buffer is ok. */
             enter_ca_mode = exit_ca_mode = NULL; /* Avoid secondary buffer. */
 #endif
@@ -545,7 +546,7 @@ static void init_term(void)
             if (!set_scroll_region)
                 set_scroll_region = "\033[%i%d;%dr";
         }
-        if (strcmp(TERM, "linux") == 0) {
+        if (strcmp(term, "linux") == 0) {
             /* Many "linux" termcaps mistakenly omit "ks" and "ke". */
             if (!keypad_on && !keypad_off) {
 		keypad_on = "\033[?1h\033=";
@@ -1089,7 +1090,7 @@ static void rewrap(Screen *screen)
 
     /* recalculate bot within last lline */
     screen->bot = screen->pline.tail;
-    while (screen->bot->prev) {
+    while (screen->bot && screen->bot->prev) {
 	pl = screen->bot->datum;
 	if (pl->start == 0 || pl->start < old_bot_visible) break;
 	screen->bot = screen->bot->prev;
@@ -1111,7 +1112,7 @@ static void rewrap(Screen *screen)
 
     /* recalculate maxbot within last lline */
     screen->maxbot = screen->pline.tail;
-    while (screen->maxbot->prev) {
+    while (screen->maxbot && screen->maxbot->prev) {
 	pl = screen->maxbot->datum;
 	if (pl->start == 0 || pl->start < old_maxbot_visible) break;
 	screen->maxbot = screen->maxbot->prev;
@@ -3502,10 +3503,11 @@ void hide_screen(Screen *screen)
     PhysLine *pl;
 
     if (!screen) screen = fg_screen;
+    if (!screen) return;
     if (screen->viewsize > 0) {
 	/* delete any temp lines in [top,bot] */
 	int done;
-	for (done = 0, node = screen->top; !done; node = next) {
+	for (done = 0, node = screen->top; !done && node; node = next) {
 	    done = (node == screen->bot);
 	    next = node->next;
 	    pl = node->datum;

--- a/src/pattern.c
+++ b/src/pattern.c
@@ -228,8 +228,10 @@ int tf_reg_exec(RegInfo *ri,
     if (Sstr) {
 	str = Sstr->data;
 	len = Sstr->len;
-    } else {
+    } else if (str) {
 	len = strlen(str);
+    } else {
+	return 0;
     }
     result = pcre2_match(ri->re, (PCRE2_SPTR)str, len, startoffset,
 	startoffset ? PCRE2_NOTBOL : 0, ri->match_data, NULL);
@@ -440,7 +442,7 @@ int smatch(const char *pat, const char *str)
 
         case '}': case '|':
             if (inword) return (*str && !is_space(*str));
-            /* else FALL THROUGH to default case */
+            /* fallthrough */
 
         default:
             if (lcase(*pat++) != lcase(*str++)) return 1;

--- a/src/port.h
+++ b/src/port.h
@@ -41,7 +41,18 @@
 # define PURE
 #endif
 #ifndef NORET
-# define NORET
+# ifdef __GNUC__
+#  define NORET __attribute__ ((noreturn))
+# else
+#  define NORET
+# endif
+#endif
+#ifndef RETURNS_NONNULL
+# ifdef __GNUC__
+#  define RETURNS_NONNULL __attribute__ ((returns_nonnull))
+# else
+#  define RETURNS_NONNULL
+# endif
 #endif
 
 #if 0

--- a/src/process.c
+++ b/src/process.c
@@ -69,7 +69,7 @@ typedef struct Proc {
 
 static struct Value *killproc(Proc *proc, int needresult);
 
-static void format_approx_interval(char *buf, struct timeval *tv);
+static void format_approx_interval(char *buf, size_t size, struct timeval *tv);
 static void nukeproc(Proc *proc);
 static int  runproc(Proc *proc);
 static int  do_repeat(Proc *proc);
@@ -83,16 +83,24 @@ static Proc *proclist = NULL;		/* head of process list */
 static Proc *proctail = NULL;		/* tail of process list */
 
 
-static void format_approx_interval(char *buf, struct timeval *tvp)
+static void format_approx_interval(char *buf, size_t size, struct timeval *tvp)
 {
-    if (tvp->tv_sec >= 60*60*100)
-        sprintf(buf, "%6ld h", (long)tvp->tv_sec/3600);
-    else if (tvp->tv_sec >= 60)
-        sprintf(buf, "%2ld:%02ld:%02ld", (long)tvp->tv_sec/3600,
+    long h = (long)tvp->tv_sec/3600;
+    if (tvp->tv_sec >= 60*60*100) {
+        if (h > 999999) h = 999999;
+        snprintf(buf, size, "%6ld h", h);
+    } else if (tvp->tv_sec >= 60) {
+        snprintf(buf, size, "%2ld:%02ld:%02ld", h,
             (long)(tvp->tv_sec/60) % 60, (long)tvp->tv_sec % 60);
-    else
-        sprintf(buf, "%4ld.%03ld",
-            (long)tvp->tv_sec, (long)tvp->tv_usec / 1000);
+    } else {
+        long sec = (long)tvp->tv_sec;
+        long usec = (long)tvp->tv_usec / 1000;
+        if (sec < 0) sec = 0;
+        if (sec > 59) sec = 59;
+        if (usec < 0) usec = 0;
+        if (usec > 999) usec = 999;
+        snprintf(buf, size, "%4ld.%03ld", sec, usec);
+    }
 }
 
 struct Value *handle_ps_command(String *args, int offset)
@@ -149,7 +157,7 @@ struct Value *handle_ps_command(String *args, int offset)
             if (next.tv_sec < 0 || next.tv_usec < 0)
                 sprintf(nbuf, "%8s", "pending");
             else if (next.tv_sec >= 0)
-                format_approx_interval(nbuf, &next);
+                format_approx_interval(nbuf, sizeof(nbuf), &next);
         }
         sprintf(obuf, "%-8.8s ", p->world ? p->world->name : "");
         if (p->ptime.tv_sec == PTIME_SYNC) {
@@ -159,7 +167,7 @@ struct Value *handle_ps_command(String *args, int offset)
         } else if (p->ptime.tv_sec < 0) {
             strcpy(obuf+9, "        ");
         } else {
-            format_approx_interval(obuf+9, &p->ptime);
+            format_approx_interval(obuf+9, sizeof(obuf) - 9, &p->ptime);
         }
         if (p->type == P_REPEAT) {
             char cbuf[32];
@@ -170,7 +178,7 @@ struct Value *handle_ps_command(String *args, int offset)
             oprintf("%5d %s r   %s %5s %S",
                 p->pid, nbuf, obuf, cbuf, p->cmd);
         } else {
-	    char disp;
+	    char disp = '?';
 	    switch (p->disp) {
 	    case DISP_ECHO: disp = 'e'; break;
 	    case DISP_SEND: disp = 's'; break;
@@ -202,6 +210,7 @@ static struct Value *newproc(int type, int (*func)(Proc *proc), int count,
     if (type == P_REPEAT) {
 	if (!(proc->prog = compile_tf(CS(cmd), 0, SUB_MACRO, 0, 0))) {
 	    Stringfree(cmd);
+	    FREE(proc);
 	    return shareval(val_zero);
 	}
     } else {
@@ -508,8 +517,10 @@ static int procopt(const char *opts, String *args, int *offsetp,
                 return FALSE;
             break;
         case 's':
-            if ((*subflag = enum2int(ptr, 0, enum_sub, "-s")) < 0)
-                return FALSE;
+            if (subflag) {
+                if ((*subflag = enum2int(ptr, 0, enum_sub, "-s")) < 0)
+                    return FALSE;
+            }
             break;
         case 'S':
             ptime->tv_sec = PTIME_SYNC;
@@ -518,8 +529,10 @@ static int procopt(const char *opts, String *args, int *offsetp,
             ptime->tv_sec = PTIME_PROMPT;
             break;
         case 'd':
-            if ((*disp = enum2int(ptr, 0, enum_disp, "-d")) < 0)
-                return FALSE;
+            if (disp) {
+                if ((*disp = enum2int(ptr, 0, enum_disp, "-d")) < 0)
+                    return FALSE;
+            }
             break;
         case 'n':
             *delay = FALSE;

--- a/src/search.c
+++ b/src/search.c
@@ -270,6 +270,8 @@ void encqueue(CQueue *cq, void *datum)
 {
     if (!cq->data)
         alloc_cqueue(cq, cq->maxsize);
+    if (!cq->data)
+        return;
     if (cq->size == cq->maxsize) {
         cq->free(cq->data[cq->first], __FILE__, __LINE__);
         cq->first = nmod(cq->first + 1, cq->maxsize);

--- a/src/signals.c
+++ b/src/signals.c
@@ -399,9 +399,10 @@ void crash(int internal, const char *fmt, const char *file, int line, long n)
 	fclose(dumpfile);
     debugger_dump();
     raise(SIGQUIT);
+    abort();
 }
 
-static char dumpname[32] = "................................";
+static char dumpname[64];
 static char exebuf[PATH_MAX+1];
 static const char *initial_path = NULL;
 static char initial_dir[PATH_MAX+1] = "."; /* default: many users never chdir */
@@ -493,20 +494,42 @@ static const char *get_exename(pid_t pid)
 	return argv0;
     }
     if (strchr(argv0, '/')) {
-	sprintf(exebuf, "%s/%s", initial_dir, argv0);
-	return exebuf;
+	if (strlen(initial_dir) + 1 + strlen(argv0) < sizeof(exebuf)) {
+	    strcpy(exebuf, initial_dir);
+	    strcat(exebuf, "/");
+	    strcat(exebuf, argv0);
+	    return exebuf;
+	}
+	return NULL;
     }
     if (!initial_path || !*initial_path)
 	return NULL;
     dir = initial_path;
     while (1) {
 	len = strcspn(dir, ":\0");
-	if (*dir == '/')
-	    sprintf(exebuf, "%.*s/%s", (int) len, dir, argv0);
-	else
-	    sprintf(exebuf, "%s/%.*s/%s", initial_dir, (int) len, dir, argv0);
+	if (*dir == '/') {
+	    if (len + 1 + strlen(argv0) < sizeof(exebuf)) {
+		memcpy(exebuf, dir, len);
+		exebuf[len] = '/';
+		strcpy(exebuf + len + 1, argv0);
+	    } else {
+		goto next_dir;
+	    }
+	} else {
+	    size_t id_len = strlen(initial_dir);
+	    if (id_len + 1 + len + 1 + strlen(argv0) < sizeof(exebuf)) {
+		strcpy(exebuf, initial_dir);
+		exebuf[id_len] = '/';
+		memcpy(exebuf + id_len + 1, dir, len);
+		exebuf[id_len + 1 + len] = '/';
+		strcpy(exebuf + id_len + 1 + len + 1, argv0);
+	    } else {
+		goto next_dir;
+	    }
+	}
 	if (stat(exebuf, &statbuf) == 0)
 	    return exebuf;
+next_dir:
 	if (!dir[len])
 	    break;
 	dir += len + 1;
@@ -541,10 +564,10 @@ static int debugger_dump(void)
 	} else {
 	    /* child */
 	    char inname[1024];
-	    char cmd[2048];
+	    char cmd[8192];
 	    int retval;
-	    sprintf(inname, "%.1000s/tf.gdb", TFLIBDIR);
-	    sprintf(cmd, "chmod go-rwx %s; gdb -n -batch -x %s '%s' %d "
+	    snprintf(inname, sizeof(inname), "%.1000s/tf.gdb", TFLIBDIR);
+	    snprintf(cmd, sizeof(cmd), "chmod go-rwx %s; gdb -n -batch -x %s '%s' %d "
 		">>%s 2>&1", dumpname, inname, exename, tf_pid, dumpname);
 	    retval = system(cmd);
 	    exit(shell_status(retval) == 0 ? 0 : 1);

--- a/src/socket.c
+++ b/src/socket.c
@@ -1458,6 +1458,10 @@ static void setupnextconn(Sock *sock)
     if (sock->fd >= 0)
 	close(sock->fd);
 retry:
+    if (!next) {
+	sock->addr = NULL;
+	return;
+    }
     next = next->ai_next;
     /* if next address is a duplicate of one we've already done, skip it */
     for (ai = sock->addrs; next && ai != next; ai = ai->ai_next) {
@@ -1502,8 +1506,10 @@ static int openconn(Sock *sock)
                 CONFAIL(xsock, "read", strerror(errno));
             else
 		CONFAILHP(xsock, gai_strerror(info.err));
-            close(xsock->fd);
-            xsock->fd = -1;
+            if (xsock->fd >= 0) {
+                close(xsock->fd);
+                xsock->fd = -1;
+            }
 # ifdef PLATFORM_UNIX
 	    if (xsock->pid >= 0)
 		if (waitpid(xsock->pid, NULL, 0) < 0)
@@ -1519,7 +1525,9 @@ static int openconn(Sock *sock)
 	    xsock->addrs = XMALLOC(info.size);
 	    read(xsock->fd, (char*)xsock->addrs, info.size);
 	}
-        close(xsock->fd);
+        if (xsock->fd >= 0) {
+            close(xsock->fd);
+        }
 # ifdef PLATFORM_UNIX
         if (xsock->pid >= 0)
             if (waitpid(xsock->pid, NULL, 0) < 0)
@@ -2124,24 +2132,26 @@ static void killsock(Sock *sock)
  */
 static void nukesock(Sock *sock)
 {
+    if (!sock) return;
     if (sock->queue.list.head) {
 	internal_error(__FILE__, __LINE__, "socket %s has unprocessed lines",
-	    !sock ? "!sock" :
 	    !sock->world ? "!sock->world" :
 	    sock->world->name);
 	socks_with_lines--;
     }
     if (sock == xsock) xsock = NULL;
-    sock->world->sock = NULL;
+    if (sock->world) {
+        sock->world->sock = NULL;
+    }
     killsock(sock);
     *((sock == hsock) ? &hsock : &sock->prev->next) = sock->next;
     *((sock == tsock) ? &tsock : &sock->next->prev) = sock->prev;
-    if (sock->world->screen->active) {
+    if (sock->world && sock->world->screen && sock->world->screen->active) {
 	sock->world->screen->active = 0;
         --active_count;
         update_status_field(NULL, STAT_ACTIVE);
     }
-    if (sock->world->flags & WORLD_TEMP) {
+    if (sock->world && (sock->world->flags & WORLD_TEMP)) {
         nuke_world(sock->world);
         sock->world = NULL;
     }
@@ -2620,6 +2630,11 @@ int send_line(const char *src, unsigned int len, int eol_flag)
     String *encoded;
 #endif
 
+    if (!src) {
+        src = "";
+        len = 0;
+    }
+
 
     if (!xsock ||
 	(xsock->constate != SS_CONNECTED && !(xsock->flags & SOCKECHO)))
@@ -2658,6 +2673,9 @@ int send_line(const char *src, unsigned int len, int eol_flag)
         bufferlen = needed;
         buffer1 = XREALLOC(buffer1, bufferlen);
         buffer2 = XREALLOC(buffer2, bufferlen);
+    }
+    if (!buffer1 || !buffer2) {
+        return 0;
     }
 
     memcpy(buffer1, src, len);
@@ -2774,9 +2792,11 @@ void world_output(World *world, conString *line)
     Sock *saved_xsock = xsock;
     xsock = world ? world->sock : NULL;
     line->links++;
-    recordline(world->history, line);
+    if (world) {
+        recordline(world->history, line);
+    }
     record_global(line);
-    if (world->sock && (world->sock->constate < SS_DEAD) &&
+    if (world && world->sock && (world->sock->constate < SS_DEAD) &&
 	!(gag && (line->attrs & F_GAG)))
     {
         if (world->sock == fsock) {
@@ -2784,21 +2804,23 @@ void world_output(World *world, conString *line)
         } else {
 	    static int preactivity_depth = 0; /* avoid recursion */
 	    /* line was already tested for gag, so it WILL print */
-	    if (!preactivity_depth && !world->screen->active) {
+	    if (!preactivity_depth && world->screen && !world->screen->active) {
 		preactivity_depth++;
                 do_hook(H_PREACTIVITY, NULL, "%s", world->name);
 		preactivity_depth--;
 	    }
-            enscreen(world->screen, line); /* ignores preactivity_depth */
-            if (!preactivity_depth) {
-		if (!world->screen->active && !(line->attrs & F_NOACTIVITY)) {
-		    world->screen->active = 1;
-		    ++active_count;
-		    update_status_field(NULL, STAT_ACTIVE);
-		    do_hook(H_ACTIVITY, "%% Activity in world %s", "%s",
-			world->name);
-		}
-		do_hook(H_BGTEXT, NULL, "%s", world->name);
+            if (world->screen) {
+                enscreen(world->screen, line); /* ignores preactivity_depth */
+                if (!preactivity_depth) {
+		    if (!world->screen->active && !(line->attrs & F_NOACTIVITY)) {
+		        world->screen->active = 1;
+		        ++active_count;
+		        update_status_field(NULL, STAT_ACTIVE);
+		        do_hook(H_ACTIVITY, "%% Activity in world %s", "%s",
+			    world->name);
+		    }
+		    do_hook(H_BGTEXT, NULL, "%s", world->name);
+                }
             }
         }
     }
@@ -3263,7 +3285,7 @@ static int handle_socket_input(const char *simbuffer, int simlen, const char *en
                 case TN_EC:
                 case TN_EL:
                     valid = 1;
-		    /* Unsupported.  Fall through to default case. */
+		    /* fallthrough */
                 default:
                     if (xsock->flags & SOCKTELNET ||
                         (xsock->flags & SOCKMAYTELNET && valid))

--- a/src/tfio.c
+++ b/src/tfio.c
@@ -272,7 +272,16 @@ TFILE *tfopen(const char *name, const char *mode)
 
     if (fp) {
         errno = EAGAIN;  /* in case malloc fails */
-        if (!(result = (TFILE*)MALLOC(sizeof(TFILE)))) return NULL;
+        if (!(result = (TFILE*)MALLOC(sizeof(TFILE)))) {
+#ifdef PLATFORM_UNIX
+            if (type == TF_PIPE) pclose(fp);
+            else fclose(fp);
+#else
+            fclose(fp);
+#endif
+            if (newname) FREE(newname);
+            return NULL;
+        }
         result->type = type;
         result->name = newname;
         result->id = 0;
@@ -605,7 +614,7 @@ void vSprintf(String *buf, int flags, const char *fmt, va_list ap)
             if (!(quote = (char)va_arg(ap, int))) break;
             if (!(sval = va_arg(ap, char *))) break;
 	    if (flags & SP_CHECK) sval = checkstring(sval);
-            for ( ; *sval; sval = q) {
+            for (q = sval; *sval; sval = q) {
 		if (*fmt == 'b' && !is_print(*q)) {
 		    if (max < 4) break;
 		    max -= 4;

--- a/src/util.c
+++ b/src/util.c
@@ -1100,3 +1100,22 @@ void die(const char *why, int err)
     }
     exit(1);
 }
+
+char *tf_strdup(const char *src, const char *file, int line)
+{
+    char *dest;
+    if (!src) return NULL;
+    dest = (char *)xmalloc(NULL, strlen(src) + 1, file, line);
+    strcpy(dest, src);
+    return dest;
+}
+
+char *tf_strndup(const char *src, size_t len, const char *file, int line)
+{
+    char *dest;
+    if (!src) return NULL;
+    dest = (char *)xmalloc(NULL, len + 1, file, line);
+    memcpy(dest, src, len);
+    dest[len] = '\0';
+    return dest;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -32,10 +32,11 @@ struct feature {
 #define localize(c)  ((is_print(c) || is_cntrl(c)) ? (c) : (c) & 0x7F)
 #endif
 
-/* Note STRNDUP works only if src[len] == '\0', ie. len == strlen(src) */
-#define STRNDUP(src, len) \
-    (strcpy(xmalloc(NULL, (len) + 1, __FILE__, __LINE__), (src)))
-#define STRDUP(src)  STRNDUP((src), strlen(src))
+extern char *tf_strdup(const char *src, const char *file, int line);
+extern char *tf_strndup(const char *src, size_t len, const char *file, int line);
+
+#define STRNDUP(src, len)  tf_strndup((src), (len), __FILE__, __LINE__)
+#define STRDUP(src)        tf_strdup((src), __FILE__, __LINE__)
 
 
 #define IS_QUOTE	0x01

--- a/src/variable.c
+++ b/src/variable.c
@@ -196,7 +196,7 @@ void init_variables(void)
 	    set_str_var_direct(var, TYPE_STR, svalue);
         } else if (var->flags & VARSPECIAL) {
             /* overwrite a pre-defined special variable */
-	    Value value;
+	    Value value = {0};
 	    value.type = TYPE_STR;
 	    value.sval = svalue;
             set_special_var(var, &value, 0, 0);
@@ -560,7 +560,7 @@ Var *setvar(Var *var, Value *value, int exportflag)
 
 Var *setstrvar(Var *var, conString *sval, int exportflag)
 {
-    Value value;
+    Value value = {0};
     value.type = TYPE_STR;
     value.sval = sval;
     return setvar(var, &value, exportflag);
@@ -568,7 +568,7 @@ Var *setstrvar(Var *var, conString *sval, int exportflag)
 
 Var *setintvar(Var *var, long ival, int exportflag)
 {
-    Value value;
+    Value value = {0};
     value.type = TYPE_INT;
     value.u.ival = ival;
     return setvar(var, &value, exportflag);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -13,6 +13,7 @@
 #include "search.h"
 #include "tfio.h"
 #include "variable.h"
+#include "util.h"
 
 static int failures;
 
@@ -976,6 +977,55 @@ static void test_regex_compat(void)
 #endif
 }
 
+extern struct Value *handle_def_command(String *args, int offset);
+extern struct Value *handle_undefn_command(String *args, int offset);
+
+static void dummy_free(void *datum, const char *file, int line) {}
+
+static void test_regression_fixes(void)
+{
+    /* Test 1: STRDUP(NULL) and STRNDUP(NULL) should safely return NULL */
+    EXPECT_TRUE(STRDUP(NULL) == NULL);
+    EXPECT_TRUE(STRNDUP(NULL, 10) == NULL);
+
+    /* Test 2: Circular queue with size 0 should not crash on encqueue */
+    {
+        CQueue cq;
+        memset(&cq, 0, sizeof(CQueue));
+        init_cqueue(&cq, 0, dummy_free);
+        encqueue(&cq, (void*)"test");
+        free_cqueue(&cq);
+    }
+
+    /* Test 3: Macro definition with -P (sub-attributes) options (semicolon pointer arithmetic fix) */
+    {
+        // With semicolon
+        String *args = owned_string("-P1bold;2red test_macro_p1 = echo hello", -1, 0);
+        struct Value *ret = handle_def_command(args, 0);
+        Stringfree(args);
+        EXPECT_TRUE(ret != NULL);
+        if (ret) freeval(ret);
+
+        // Without semicolon (single element, previously triggered NULL+1 pointer arithmetic)
+        args = owned_string("-P1bold test_macro_p2 = echo hello", -1, 0);
+        ret = handle_def_command(args, 0);
+        Stringfree(args);
+        EXPECT_TRUE(ret != NULL);
+        if (ret) freeval(ret);
+        
+        // Clean up
+        args = owned_string("test_macro_p1", -1, 0);
+        ret = handle_undefn_command(args, 0);
+        Stringfree(args);
+        if (ret) freeval(ret);
+
+        args = owned_string("test_macro_p2", -1, 0);
+        ret = handle_undefn_command(args, 0);
+        Stringfree(args);
+        if (ret) freeval(ret);
+    }
+}
+
 extern void init_util1(void);
 extern void init_expand(void);
 extern void init_variables(void);
@@ -991,6 +1041,7 @@ int main(void)
     init_util2();
     init_attrs();
 
+    test_regression_fixes();
     test_encode_ansi();
     test_string_shift_attributes();
     test_display_width_helpers();


### PR DESCRIPTION
Most were uninitialized variables and type mismatches.

Also fix the findings from "scan-build"