### PR TITLE
Roll back one line of 7156aaa4 to fix function arg count regression

### DIFF
--- a/src/expr.c
+++ b/src/expr.c
@@ -59,7 +59,7 @@ static Value *valpool = NULL;		/* freelist */
 
 typedef struct ExprFunc {
     const char *name;		/* name invoked by user */
-    int min, max;		/* allowable argument counts */
+    unsigned min, max;		/* allowable argument counts */
 } ExprFunc;
 
 static ExprFunc functab[] = {


### PR DESCRIPTION
Trying to build the latest master, I was running into an issue whereby seemingly every function was erroring due to an incorrect number of args.  Here's the startup output from a clean build and install with no tfrc:

```
% Loading commands from /opt/tf/share/tf-lib/stdlib.tf.
% /opt/tf/share/tf-lib/tfstatus.tf, line 90: status_int_world: strcat: found 2 arguments,
    expected between 1 and -1
% /opt/tf/share/tf-lib/tfstatus.tf, line 90: status_int_active: pad: found 5 arguments,
    expected between 1 and -1
% /opt/tf/share/tf-lib/tfstatus.tf, line 90: status_int_mail: pad: found 4 arguments,
    expected between 1 and -1
% /opt/tf/share/tf-lib/stdlib.tf, lines 757-765: EVAL: strcat: found 3 arguments, expected
    between 1 and -1
=====
% status_int_world: strcat: found 2 arguments, expected between 1 and -1
% status_int_active: pad: found 5 arguments, expected between 1 and -1
% status_int_mail: pad: found 4 arguments, expected between 1 and -1
```

And pretty much everything after that also fails.  E.g. if I just type `/echo hello world`, I get `% echo: strcat: found 2 arguments, expected between 1 and -1`.

Using `git bisect`, I traced this down first to 7156aaa48415a19d4b4cc60b8cd0c809e40864a0, and then to a specific hunk in that commit.  It's specifically when that commit changed the type of the min and max args from `unsigned` to `int`.  This PR reverts that one change, and now TF works as I'd expect — no errors on startup, `/echo` works fine again, etc.

I will admit, it's been decades since I did any major C work, and while I know the difference between `int` and `unsigned`, I'm at a loss to figure out why this one change is causing seemingly every function to have min=1 max=-1 args.  I assumed it must be a macOS oddity at first, but then I took the tree over to my Debian Linux system, and I had the exact same problem, with the exact same fix.

I'm also aware that I'm reverting a "fix warnings" patch, meaning I'm almost certainly creating warning(s) here, but I don't get any warnings when I build and I'm not clear on how to enable them. :sweat_smile:  (Beyond just being rusty with regular C and `make`, I've also got no experience working on CMake projects.)