### PR TITLE
fix(visual): fix redraw when input is wrapped

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -2862,6 +2862,17 @@ void logical_refresh(void)
 #if !WIDECHAR
         niy = istarty + (keyboard_pos - kpos) / Wrap;
 #endif
+        /*
+         * A fresh input starts on the last row after the previous input is
+         * submitted.  If the new input wraps but still fits in the input
+         * window, move its start up so logical_refresh() redraws all of it.
+         * Otherwise the overflow path below treats the first row as clipped,
+         * leaving stale text there while placing the cursor on the last row.
+         */
+        if (niy > lines && niy - istarty < isize) {
+            istarty -= niy - lines;
+            niy = lines;
+        }
         if (niy <= lines) {
             clear_input_line();
         } else {


### PR DESCRIPTION
If in visual mode and the previous input was wrapped, pressing "up" was not redrawing the input correctly and instead just moved the cursor to where it should be drawing.